### PR TITLE
Update location of Z3 git repository in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "rewrite/lib/c4"]
     path = lib/c4
-    url = https://github.com/bloom-lang/c4/
+    url = https://github.com/bloom-lang/c4.git
 [submodule "rewrite/lib/z3"]
     path = lib/z3
-    url = https://git.codeplex.com/z3
+    url = https://github.com/Z3Prover/z3.git


### PR DESCRIPTION
The Z3 repository has moved from Codeplex to GitHub, so we need to update the `.gitmodules` file in order for `git submodule update` to work.
