### PR TITLE
Add CircleCI configuration and rewrite Makefile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "rewrite/lib/c4"]
     path = lib/c4
-    url = https://github.com/bloom-lang/c4/
+    url = https://github.com/bloom-lang/c4.git
 [submodule "rewrite/lib/z3"]
     path = lib/z3
-    url = https://git.codeplex.com/z3
+    url = https://github.com/Z3Prover/z3.git

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,16 @@ lib: .gitmodules
 	git submodule update --recursive --init
 	touch lib
 
-${LIB_Z3}: lib/z3 $(shell find lib/z3 -path lib/z3/build -prune -o -type f -print)
+lib/z3: lib
+
+lib/c4: lib
+
+${LIB_Z3}: lib lib/z3 $(shell find lib/z3 -path lib/z3/build -prune -o -type f -print)
 	rm -rf lib/z3/build
-	cd lib/z3 && python scripts/mk_make.py --prefix=z3-dist
+	cd lib/z3 && python scripts/mk_make.py
 	cd lib/z3/build && make -j4
 
-${LIB_C4}: lib/c4 $(shell find lib/c4 -path lib/c4/build -prune -o -type f -print)
+${LIB_C4}: lib lib/c4 $(shell find lib/c4 -path lib/c4/build -prune -o -type f -print)
 	rm -rf lib/c4/build
 	@which cmake > /dev/null
 	cd lib/c4 && mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,50 @@
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S), Darwin)
+	LIB_C4 = lib/c4/build/src/libc4/libc4.dylib
+	LIB_Z3 = lib/z3/build/libz3.dylib
+else
+	LIB_C4 = lib/c4/build/src/libc4/libc4.so
+	LIB_Z3 = lib/z3/build/libz3.so
+endif
+
+LIBRARY_PATH = $(shell pwd)/$(shell dirname ${LIB_C4}):$(shell pwd)/$(shell dirname ${LIB_Z3})
+LD_LIBRARY_PATH = ${LIBRARY_PATH}:$(shell $$LD_LIBRARY_PATH)
+DYLD_LIBRARY_PATH = ${LIBRARY_PATH}:$(shell $$DYLD_LIBRARY_PATH)
+
 all: deps
 
-deps: get-submodules c4 z3
+deps: ${LIB_C4} ${LIB_Z3}
 
 clean-deps:
-	rm -r lib/c4/build
-	rm -r lib/z3/build
+	rm -rf lib/c4/build
+	rm -rf lib/z3/build
 
-c4: lib/c4/build/src/libc4/libc4.dylib
+lib: .gitmodules
+	git submodule sync
+	git submodule update --recursive --init
+	touch lib
 
-z3: lib/z3/build/z3-dist
-
-lib/z3/build/z3-dist: lib/z3/build/libz3.dylib
-	# We need to make these parent directories so that Z3's Makefile
-	# doesn't complain about them missing when it copies files during
-	# the `install` step:
-	mkdir -p lib/z3/build/z3-dist/lib/python2.7/dist-packages
-	mkdir -p lib/z3/build/z3-dist/lib/python2.6/dist-packages
-	cd lib/z3/build && make install
-
-lib/z3/build/libz3.dylib:
+${LIB_Z3}: lib/z3 $(shell find lib/z3 -path lib/z3/build -prune -o -type f -print)
+	rm -rf lib/z3/build
 	cd lib/z3 && python scripts/mk_make.py --prefix=z3-dist
 	cd lib/z3/build && make -j4
 
-lib/c4/build/src/libc4/libc4.dylib:
+${LIB_C4}: lib/c4 $(shell find lib/c4 -path lib/c4/build -prune -o -type f -print)
+	rm -rf lib/c4/build
 	@which cmake > /dev/null
 	cd lib/c4 && mkdir -p build
 	cd lib/c4/build && cmake ..
 	cd lib/c4/build && make
 
-get-submodules:
-	git submodule init
-	git submodule update
-
-CMAKE-installed:
+test: deps
+	export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" && \
+	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" && \
+	sbt coverage test
 
 # SBT command for running only the fast unit tests and excluding the slower
 # end-to-end tests (which have been tagged using ScalaTest's `Slow` tag):
 fast-test: deps
-	sbt "testOnly *Suite -- -l org.scalatest.tags.Slow"
+	export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" && \
+	export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" && \
+	sbt coverage "testOnly * -- -l org.scalatest.tags.Slow"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Molly: Lineage-driven Fault Injection
 
+[![Circle CI](https://circleci.com/gh/palvaro/molly.svg?style=svg)](https://circleci.com/gh/palvaro/molly) [![codecov.io](https://codecov.io/github/palvaro/molly/coverage.svg?branch=master)](https://codecov.io/github/palvaro/molly?branch=master)
+
 ## Installation
 
 Molly is written in Scala and compiled using SBT.  Molly depends on the [C4 Overlog runtime](https://github.com/bloom-lang/c4) and [Z3 theorem prover](https://z3.codeplex.com/).
@@ -12,7 +14,7 @@ The top-level `Makefile` should be handle a one-click build on OS X.
 Add the native library dependencies to your loader path.  On OS X:
 
 ```
-export LD_LIBRARY_PATH=lib/c4/build/src/libc4/:lib/z3/build/z3-dist/lib/
+export LD_LIBRARY_PATH=lib/c4/build/src/libc4/:lib/z3/build/
 ```
 
 Run

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,24 @@
+machine:
+  python:
+      version: 2.7.6
+
+checkout:
+  post:
+    # From https://tschottdorf.github.io/cockroach-docker-circleci-continuous-integration/
+    # For every file tracked by Git, this sets its timestamp to the timestamp of the last
+    # commit that changed the file.
+    - for x in $(git ls-tree --full-tree --name-only -r HEAD); do touch -t $(date -d "$(git log -1 --format=%ci "${x}")" +%y%m%d%H%M.%S) "${x}"; done
+
+dependencies:
+  override:
+    - pip install codecov
+    - make deps
+    - sbt test:compile  # to resolve dependencies
+  cache_directories:
+    - "lib"
+
+test:
+  override:
+    - make test
+  post:
+    - codecov

--- a/project/MollyBuild.scala
+++ b/project/MollyBuild.scala
@@ -7,7 +7,6 @@ object BuildSettings {
     organization := "edu.berkeley.cs.boom",
     version := "0.1-SNAPSHOT",
     scalaVersion := "2.11.6",
-    //scalaVersion := "2.10.3",
     resolvers ++= Seq(
       Resolver.sonatypeRepo("snapshots"),
       Resolver.sonatypeRepo("releases"),
@@ -28,7 +27,6 @@ object MollyBuild extends Build {
     settings = buildSettings ++ Seq(
       scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
       scalaVersion in scalaZ3 := "2.11.2",
-      scalaVersion in "bloom-compiler" := "2.10.3",
       libraryDependencies ++= Seq(
         "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
         "org.slf4j" % "slf4j-log4j12" % "1.7.5",
@@ -50,11 +48,13 @@ object MollyBuild extends Build {
         "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13",
         "com.github.tototoshi" %% "scala-csv" % "1.0.0",
         "com.lihaoyi" %% "pprint" % "0.3.6",
-        "com.github.nikita-volkov" % "sext" % "0.2.4",
-        "com.github.vagm" %% "optimus" % "1.2.1"
+        "com.github.nikita-volkov" % "sext" % "0.2.4"
       )
     )
-  ).dependsOn(scalaZ3)
+  ).dependsOn(scalaZ3, optimus)
 
   lazy val scalaZ3 = RootProject(uri("git://github.com/JoshRosen/ScalaZ3.git#7c3d7801c7b312433f06101414aeb3a7f9f30433"))
+
+  // Optimus's scalaVersion is 2.11.7
+  lazy val optimus = ProjectRef(uri("git://github.com/vagm/optimus.git#v1.2.1"), "optimus")
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")


### PR DESCRIPTION
This PR rewrites Molly's Makefile and adds configurations for testing on CircleCI and gathering coverage metrics with https://codecov.io. For an example of what the CircleCI output looks like, see https://circleci.com/gh/JoshRosen/molly/32. For a sample code coverage report, see https://codecov.io/github/JoshRosen/molly/src/main/scala/edu/berkeley/cs/boom/molly?ref=53f2d67600faf1848b2708e8b6623f178cb6ed55. The coverage is currently reported as being fairly low, but that's because Molly has several large CLI interfaces which aren't exercised in the current tests. You can tell Codecov to ignore those paths if you don't want that to count towards your reported coverage percentage.

The only real trickiness in this is getting the Makefile dependencies to work well with CircleCI's dependency caching. If necessary, the Makefile will build both C4 and Z3 from source, but this is an expensive process that we'd like to avoid if at all possible. The basic strategy implemented here is to tie the invalidation of the `.so`/`.dylib` targets to the timestamps of the commits that changed `.gitmodules` or the submodule SHAs.

Our original reason for building Z3 from source was the fact that older Z3 binary releases did not contain the `libz3` artifacts, but this has been [fixed in newer releases](https://github.com/Z3Prover/z3/releases). An advantage of the current approach is that we don't have to worry about the target architecture and don't need to burden the user / developer with installing the right binary for their platform (Z3 doesn't publish binaries that are targeted for older OS X versions, for example).

After merging this, visit https://circleci.com/add-projects in order to enable CircleCI for this repo. This PR currently incorporates the changes in #1 and #2, so it may need to be rebased after those are merged.
